### PR TITLE
Enable the ability to create new "readonly" record

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,15 @@ Or if you are off-rails, but use ActiveRecord, just do this in the model class:
 
 ### Configuration
 
-Useful if you'd like to turn off read-only only for tests, etc.
+You can create an initializer (`/config/initializers/activerecord-be_readonly.rb`) with the following options:
 
-    # application-wide setting. true by default.
-    BeReadonly.enabled = false
+To turn off read-only application-wide, set the enabled setting to false (useful if you'd like to turn off read-only only for tests, etc.)
+
+    BeReadonly.enabled = false    # Default: true
+
+To disable read-only for record creation application-wide, set the create_allowed setting to true
+
+    BeReadonly.create_allowed = true    # Default: false
 
 ### Contributors
 
@@ -52,6 +57,7 @@ Thanks to:
 * [vkhater](https://github.com/vkhater)
 * [Gabriel Naiman](https://github.com/gabynaiman)
 * [Gary Weaver](https://github.com/garysweaver)
+* [Kevin Zych](https://github.com/kayzee)
 
 ### License
 

--- a/lib/activerecord-be_readonly/config.rb
+++ b/lib/activerecord-be_readonly/config.rb
@@ -1,7 +1,9 @@
 module BeReadonly
   class << self
     attr_accessor :enabled
+    attr_accessor :create_allowed
   end
 end
 
 BeReadonly.enabled = true
+BeReadonly.create_allowed = false

--- a/lib/activerecord-be_readonly/model.rb
+++ b/lib/activerecord-be_readonly/model.rb
@@ -32,7 +32,7 @@ module BeReadonly
 
     module BeReadonlyInstanceMethods
       def readonly?
-        return new_record? ? false : true if BeReadonly.enabled
+        return true if BeReadonly.enabled && !(BeReadonly.create_allowed && new_record?)
         super
       end
 

--- a/lib/activerecord-be_readonly/model.rb
+++ b/lib/activerecord-be_readonly/model.rb
@@ -32,7 +32,7 @@ module BeReadonly
 
     module BeReadonlyInstanceMethods
       def readonly?
-        return true if BeReadonly.enabled
+        return new_record? ? false : true if BeReadonly.enabled
         super
       end
 


### PR DESCRIPTION
Currently, if a model is "be_readonly", no new records can be created. This defeats the purpose since you can never create records that will be readonly.