### PR TITLE
Add necessary ActiveSupport requires

### DIFF
--- a/lib/activerecord-be_readonly/model.rb
+++ b/lib/activerecord-be_readonly/model.rb
@@ -1,3 +1,5 @@
+require 'active_support'
+
 module BeReadonly
   module Model
     extend ActiveSupport::Concern

--- a/lib/activerecord-be_readonly/now.rb
+++ b/lib/activerecord-be_readonly/now.rb
@@ -1,3 +1,5 @@
+require 'active_support'
+
 module BeReadonly
   module Now
     extend ActiveSupport::Concern


### PR DESCRIPTION
When run from a rake task, there is an assumption that activesupport is required. An error occurs:

`NameError: uninitialized constant BeReadonly::Model::ActiveSupport`

Some requires are ... required.