### PR TITLE
Support Rails 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Be Readonly for ActiveRecord 3.x/4.x/5.x and Rails 3.x/4.x/5.x
+Be Readonly for ActiveRecord 3.x/4.x/5.x/6.x and Rails 3.x/4.x/5.x/6.x
 =====
 
 Makes any ActiveRecord model become read-only in Rails with:

--- a/activerecord-be_readonly.gemspec
+++ b/activerecord-be_readonly.gemspec
@@ -8,9 +8,9 @@ Gem::Specification.new do |s|
   s.authors     = ['Gary S. Weaver']
   s.email       = ['garysweaver@gmail.com']
   s.homepage    = 'https://github.com/garysweaver/activerecord-be_readonly'
-  s.summary     = %q{Easy read-only models for ActiveRecord 3.x/4.x/5.x.}
-  s.description = %q{Makes read-only models easier to implement in ActiveRecord 3.x/4.x/5.x.}
+  s.summary     = %q{Easy read-only models for ActiveRecord 3.x/4.x/5.x/6.x.}
+  s.description = %q{Makes read-only models easier to implement in ActiveRecord 3.x/4.x/5.x/6.x.}
   s.files = Dir['lib/**/*'] + ['Rakefile', 'README.md']
   s.license = 'MIT'
-  s.add_dependency 'activerecord', '>= 3.0', '< 6'
+  s.add_dependency 'activerecord', '>= 3.0', '< 7'
 end


### PR DESCRIPTION
Rails 6.0 has been released. I think there is no problem with activerecord-be_readonly supporting AR 6.0 and Rails 6.0. Thank you.